### PR TITLE
Support reftest wait

### DIFF
--- a/lib/viewer.js
+++ b/lib/viewer.js
@@ -18814,6 +18814,8 @@
 	      scenario: _this.currentScenario,
 	      styles: _this.opts.styles
 	    }));
+
+	    document.documentElement.className = '';
 	  }
 	};
 
@@ -18919,6 +18921,7 @@
 	  if (!location.search) {
 	    return;
 	  }
+	  document.documentElement.className = 'reftest-wait"';
 
 	  var query_params = location.search.substr(1).split('&');
 	  var params = {};

--- a/lib/viewer.js
+++ b/lib/viewer.js
@@ -18941,7 +18941,7 @@
 	      var inner = _step.value;
 
 	      if (inner.textContent == params['inner']) {
-	        inner.onclick();
+	        inner.click();
 	        scenarios = inner.parentNode.querySelectorAll('.scenario');
 	      }
 	    }
@@ -18969,7 +18969,7 @@
 	      var scenario = _step2.value;
 
 	      if (scenario.textContent == params['scenario']) {
-	        scenario.onclick();
+	        scenario.click();
 	      }
 	    }
 	  } catch (err) {

--- a/src/tags/frame.tag
+++ b/src/tags/frame.tag
@@ -13,6 +13,8 @@
           scenario: this.currentScenario,
           styles: this.opts.styles
         }));
+
+        document.documentElement.className = '';
       }
     }
 
@@ -106,6 +108,7 @@
     window.onload = () => {
 
       if (! location.search){ return; }
+      document.documentElement.className = 'reftest-wait"';
 
       let query_params = location.search.substr(1).split('&');
       let params = {};

--- a/src/tags/frame.tag
+++ b/src/tags/frame.tag
@@ -122,14 +122,14 @@
       let inners = document.querySelectorAll('viewer-component > div.inner');
       for(let inner of inners) {
         if (inner.textContent == params['inner']){
-          inner.onclick();
+          inner.click();
           scenarios = inner.parentNode.querySelectorAll('.scenario');
         }
       }
 
       for(let scenario of scenarios) {
         if (scenario.textContent == params['scenario']){
-          scenario.onclick();
+          scenario.click();
         }
       }
 


### PR DESCRIPTION
http://efcl.info/2015/05/14/reftest-runner/#非同期のテスト へ対応して、component viewer からキャプチャのdiffが取れるようにしました。

ex.

```
npm install reftest-runner -g
gulp compoennts
reftest-runner --targetB http://localhost:3000 --targetA "http://localhost:3000/viewer.html?inner=header.riot&scenario=scenario%202" --useExternalServer -b firefox
```

log

![2015_08_19__21-51-13-viewer html-vs-1](https://cloud.githubusercontent.com/assets/395584/9356726/a6abd86c-46bd-11e5-96d2-f142c719e62a.png)
